### PR TITLE
feat(log-warn-on-cdn-npm-version-mismatch)

### DIFF
--- a/fixtures/version.html
+++ b/fixtures/version.html
@@ -1,0 +1,6 @@
+<head>
+  <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v1.x.x/dist/alpine.min.js" defer></script>
+</head>
+<body>
+  <div x-data="{}"></div>
+</body>

--- a/src/version-mismatch.js
+++ b/src/version-mismatch.js
@@ -1,0 +1,24 @@
+/**
+ *
+ * @param {Document} document - document from which Alpine components are being loaded from
+ * @param {string} alpineVersion - Alpine.js version from NPM
+ * @returns {void}
+ */
+function checkVersionMismatch(document, alpineVersion) {
+  if (document.scripts.length === 0) return;
+  const alpineScript = [...document.scripts].find(
+    (s) => s.src.includes('dist/alpine') || s.src.includes('alpinejs/alpine')
+  );
+  if (!alpineScript) return;
+  // Match v1.x.x, v2.x.x etc (the bit between @ and /)from
+  // `https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.min.js`
+  const [jsDelivrVersion] = alpineScript.src.match(/(?<=@v)[a-z|\d.]*(?=\/)/gm);
+  const cdnMajorVersion = jsDelivrVersion[0];
+  if (!alpineVersion.startsWith(cdnMajorVersion)) {
+    console.warn(
+      `alpine-test-utils: Alpine.js version is different to CDN one, requested "${jsDelivrVersion}", testing with "${alpineVersion}"`
+    );
+  }
+}
+
+module.exports = {checkVersionMismatch};

--- a/tests/version.js
+++ b/tests/version.js
@@ -1,0 +1,28 @@
+import test from 'ava';
+import path from 'path';
+import {load} from '../src/main';
+import Alpine from 'alpinejs';
+
+const stub = (fn) => {
+  const calls = [];
+  const callable = (...args) => {
+    calls.push(args);
+    fn(...args);
+  };
+
+  callable.calls = calls;
+  callable.firstCall = () => calls[0];
+  return callable;
+};
+
+test('load - Alpine.js version mismatch', async (t) => {
+  console.warn = stub(() => {});
+  const component = await load(
+    path.join(__dirname, '../fixtures/version.html')
+  );
+  t.is(component, `<div x-data="{}"></div>`);
+  t.is(
+    console.warn.firstCall()[0],
+    `alpine-test-utils: Alpine.js version is different to CDN one, requested "1.x.x", testing with "${Alpine.version}"`
+  );
+});


### PR DESCRIPTION
Closes #1

When using `load` check `document.scripts` for Alpine.js being loaded from CDN, if it is, use the version range from there to check against npm version.